### PR TITLE
ci: fix semantic-release permissions and configuration

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -105,12 +105,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, validate]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.has-changes == 'true'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -120,32 +125,6 @@ jobs:
       - name: Install semantic-release
         run: |
           npm install -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github
-
-      - name: Create .releaserc.json
-        run: |
-          cat > .releaserc.json << 'EOF'
-          {
-            "branches": ["main"],
-            "plugins": [
-              "@semantic-release/commit-analyzer",
-              "@semantic-release/release-notes-generator",
-              [
-                "@semantic-release/changelog",
-                {
-                  "changelogFile": "CHANGELOG.md"
-                }
-              ],
-              [
-                "@semantic-release/git",
-                {
-                  "assets": ["CHANGELOG.md"],
-                  "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-                }
-              ],
-              "@semantic-release/github"
-            ]
-          }
-          EOF
 
       - name: Run semantic-release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,21 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
# Fix semantic-release pipeline configuration

## Changes
- Add `.releaserc.json` as permanent config file (no longer generated during pipeline)
- Update release job to use `SEMANTIC_RELEASE_TOKEN` for protected branch access
- Add explicit job permissions for security best practices
- Remove inline config file generation

## Why
- `GITHUB_TOKEN` lacks permissions for protected branches
- Inline config generation was anti-pattern
- Explicit permissions follow security best practices

## Testing
Pipeline changes only - will test semantic-release with module changes in follow-up branch.