### PR TITLE
Clean up changelog format for automated releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,6 @@
 
 * **ci:** add automated release pipeline ([#12](https://github.com/mccrackenyyc/terraform-modules/issues/12)) ([81dba39](https://github.com/mccrackenyyc/terraform-modules/commit/81dba39175996c867f2a711aee28d469c7bbe315))
 
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-### Added
-- Automated release pipeline with semantic versioning
-- TFLint configuration with Azure-specific rules
-- Conventional commits documentation
 
 ## [1.0.0] - 2025-07-07
 


### PR DESCRIPTION
# Clean up changelog format for automated releases

## Changes
- Remove manual "Changelog" header and description
- Remove "[Unreleased]" section
- Remove reference to "Keep a Changelog" approach, now solely using semantic-release syntax

## Why
After implementing semantic-release, the manual changelog sections are redundant and create formatting conflicts. semantic-release now handles all changelog generation automatically.

## Result
Clean changelog managed entirely by automation, following industry-standard format for semantic-release workflows.